### PR TITLE
Newer cf-mgmt required as breaking change happened at 0.91

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,10 @@ RUN curl -L https://github.com/cloudfoundry-incubator/credhub-cli/releases/downl
   && chmod +x /usr/local/bin/credhub \
   && rm credhub-linux-1.7.5.tgz
 
-RUN curl -L https://github.com/pivotalservices/cf-mgmt/releases/download/v0.0.87/cf-mgmt-linux -o /usr/local/bin/cf-mgmt \
+RUN curl -L https://github.com/pivotalservices/cf-mgmt/releases/download/v1.0.12/cf-mgmt-linux -o /usr/local/bin/cf-mgmt \
   && chmod +x /usr/local/bin/cf-mgmt
 
-RUN curl -L https://github.com/pivotalservices/cf-mgmt/releases/download/v0.0.87/cf-mgmt-config-linux -o /usr/local/bin/cf-mgmt-config \
+RUN curl -L https://github.com/pivotalservices/cf-mgmt/releases/download/v1.0.12/cf-mgmt-config-linux -o /usr/local/bin/cf-mgmt-config \
   && chmod +x /usr/local/bin/cf-mgmt-config
 
 RUN wget https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-2.0.48-linux-amd64 \


### PR DESCRIPTION
### What?

cf-mgmt 0.0.91 introduced a change which is not backwardly compatible with earlier versions. We need to bump this container to a newer version so that we can upgrade our workstations to a newer version too.

### How to review?
Check diffs, see that all that changed was the version number.
Hit Merge.
:-) Be Happy :-)
